### PR TITLE
Deprecate DockerCinderVolumeImage

### DIFF
--- a/source/cinder/configuration/cinder_config_files/section_rhosp161_director_flasharray_configuration.rst
+++ b/source/cinder/configuration/cinder_config_files/section_rhosp161_director_flasharray_configuration.rst
@@ -154,7 +154,7 @@ Create a new environment file ``custom_container_pure.yaml`` in the directory
 .. code-block:: bash
 
   parameter_defaults:
-    DockerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
+    ContainerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
 
 Alternatively, you may edit the container images environment file (usually
 ``overcloud_images.yaml``, created when the ``openstack overcloud container

--- a/source/cinder/configuration/cinder_config_files/section_rhosp162_director_flasharray_configuration.rst
+++ b/source/cinder/configuration/cinder_config_files/section_rhosp162_director_flasharray_configuration.rst
@@ -154,7 +154,7 @@ Create a new environment file ``custom_container_pure.yaml`` in the directory
 .. code-block:: bash
 
   parameter_defaults:
-    DockerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
+    ContainerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
 
 Alternatively, you may edit the container images environment file (usually
 ``overcloud_images.yaml``, created when the ``openstack overcloud container

--- a/source/cinder/configuration/cinder_config_files/section_rhosp16_director_flasharray_configuration.rst
+++ b/source/cinder/configuration/cinder_config_files/section_rhosp16_director_flasharray_configuration.rst
@@ -154,7 +154,7 @@ Create a new environment file ``custom_container_pure.yaml`` in the directory
 .. code-block:: bash
 
   parameter_defaults:
-    DockerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
+    ContainerCinderVolumeImage: <registry:port>/<directory>/openstack-cinder-volume-pure:latest
 
 Alternatively, you may edit the container images environment file (usually
 ``overcloud_images.yaml``, created when the ``openstack overcloud container


### PR DESCRIPTION
`Docker*Image` deprecated in favour of `Container*Image`