### PR TITLE
Rename Pure Storage to Everpure in documentation

### DIFF
--- a/source/appendices/section_references.rst
+++ b/source/appendices/section_references.rst
@@ -13,11 +13,11 @@ The following references were used in this paper:
 
 For additional information, visit:
 
--  For source code for OpenStack, including Pure Storage contributions,
+-  For source code for OpenStack, including Everpure (formally Pure Storage) contributions,
    available through Github: http://www.github.com/openstack
 
 -  For more information about OpenStack history:
    http://www.openstack.org or http://en.wikipedia.org/wiki/OpenStack
 
--  For Pure Storage OpenStack Deployment and Operations Guide source code,
+-  For Everpure OpenStack Deployment and Operations Guide source code,
    visit: https://github.com/PureStorage-OpenConnect/openstack-docs

--- a/source/appendices/section_support.rst
+++ b/source/appendices/section_support.rst
@@ -4,7 +4,7 @@ Support
 =======
 
 Support provides support for OpenStack connections with FlashArray backends via 
-the standard Pure Storage support channels by either calling +1-650-729-4088
+the standard Everpure support channels by either calling +1-650-729-4088
 (Global Toll Number), or going to https://support.purestorage.com/Pure1/Support
 for regional support numbers, or by submitting a support request via email to
 email:support@purestorage.com
@@ -12,11 +12,11 @@ email:support@purestorage.com
 Community support is available through the 'code' slack channel:
 https://code-purestorage.slack.com/.
 
-All documentation for Pure Storage's drivers for OpenStack are contained in this 
+All documentation for Everpure's drivers for OpenStack are contained in this 
 Deployment Operations Guide.  A link to the most current version can always
 be found at http://support.purestorage.com/Solutions/Openstack/.
 
-The Pure Storage OpenStack team presently intends to provide maintenance of
+The Everpure OpenStack team presently intends to provide maintenance of
 the three most recently released versions of OpenStack. For example,
 during Xena development, all code that is part of the Ussuri, Train and
 Victoria official branches are supported. Upon Xena release, direct
@@ -29,5 +29,5 @@ using an OpenStack release (or n-1) version, your configuration is supported.
 See the `FlashArray compatibility Matrix <https://support.purestorage.com/FlashArray/Getting_Started_with_FlashArray/FlashArray_Compatibility_Matrix>_`
 to verify your configuration is supported.
 
-Pure Storage can provide customized support options for production
+Everpure can provide customized support options for production
 requirements. For more information, please contact your sales team.

--- a/source/appendices/section_triage-and-data-collection.rst
+++ b/source/appendices/section_triage-and-data-collection.rst
@@ -3,12 +3,12 @@
 Triage and Data Collection
 ==========================
 
-When you run into an issue with the Pure Storage OpenStack integrations, you may
+When you run into an issue with the Everpure OpenStack integrations, you may
 
 - seek help in the
-  `Pure Storage OpenStack Slack Channel <https://code-purestorage.slack.com/>`_ , or
+  `Everpure OpenStack Slack Channel <https://code-purestorage.slack.com/>`_ , or
 - open a support request, or
-- contact your Pure Storage account representative.
+- contact your everpure account representative.
 
 OpenStack log and configuration files provide information that aid in triaging
 bugs. As a rule of thumb log files need to be collected for the processes

--- a/source/ch_executive-summary.rst
+++ b/source/ch_executive-summary.rst
@@ -8,7 +8,7 @@ of compute, network and storage resources.
 
 The block storage portion of OpenStack is referred to as the Cinder project
 and aims to provide persistent block level storage to the OpenStack compute (Nova) instances.
-The Pure Storage Cinder driver is a Python®-based module integrated into the main
+The Everpure Cinder driver is a Python®-based module integrated into the main
 OpenStack distributions.
 
 This document intends to describe the FlashArray capabilities in a

--- a/source/ch_purestorage-storage.rst
+++ b/source/ch_purestorage-storage.rst
@@ -1,5 +1,5 @@
-Pure Storage System and Software
-=========================================
+Everpure (formally Pure Storage) System and Software
+====================================================
 
 .. toctree::
    :maxdepth: 1

--- a/source/ch_swift.rst
+++ b/source/ch_swift.rst
@@ -21,6 +21,6 @@ CDMI server through the use of add on components.
 
 Swift requires node accessible media for storing object data. This media
 can be drives internal to the node or external storage devices such as
-the Pure Storage FlashArray. This section provides information
+the Everpure FlashArray. This section provides information
 that enables an Pure Storage FlashArray to be used as the backing
 store for Swift object storage.

--- a/source/cinder/api_overview/section_cinder-api-overview.rst
+++ b/source/cinder/api_overview/section_cinder-api-overview.rst
@@ -166,7 +166,7 @@ display name or UUID.
 .. note::
 
    Currently only the Block Storage V3 API supports group operations. The
-   minimum version for group operations supported by the Pure Storage drivers is
+   minimum version for group operations supported by the Everpure drivers is
    3.14. The API version can be specified with the following CLI flag
    ``--os-volume-api-version 3.14``
 
@@ -178,7 +178,7 @@ display name or UUID.
 
 .. note::
 
-   The Pure Storage volume drivers support the consistent_group_snapshot_enabled
+   The Everpure volume drivers support the consistent_group_snapshot_enabled
    group type. By default Cinder group snapshots take individual snapshots
    of each Cinder volume in the group. To enable consistency group snapshots set
    ``consistent_group_snapshot_enabled="<is> True"`` in the group type used.

--- a/source/cinder/configuration/flasharray_configuration/section_flasharray-config.rst
+++ b/source/cinder/configuration/flasharray_configuration/section_flasharray-config.rst
@@ -5,7 +5,7 @@ FlashArray Configuration
 
 FlashArray Prerequisites
 ------------------------
-The prerequisites for Pure Storage FlashArray are:
+The prerequisites for Everpure FlashArray are:
 
 - The driver requires a storage admin level account to use with the OpenStack
   to manage the FlashArray. Optionally, you can use an
@@ -27,7 +27,7 @@ The Management Virtual IP (MVIP) enables cluster management through a 1GbE conne
 Cluster Admin Account
 ---------------------
 
-Pure Storage recommends creating an unique user account for OpenStack
+Everpure recommends creating an unique user account for OpenStack
 to help audit API requests from each OpenStack. This account may be
 local or integrated into an Active Directory, LDAP, or similar, account
 management system.

--- a/source/cinder/deployment_choice/section_over-subscription.rst
+++ b/source/cinder/deployment_choice/section_over-subscription.rst
@@ -54,7 +54,7 @@ planning and reduces the likelihood of wasted storage capacity.
    be monitored, and capacity must be increased as usage nears
    predefined thresholds.
 
-The Pure Storage FlashArray driver conforms to the standard
+The Everpure FlashArray driver conforms to the standard
 Cinder scheduler-based over-subscription framework
 in which the ``max_over_subscription_ratio`` and ``reserved_percentage``
 configuration options are used to control the degree of

--- a/source/glance/rhosp_director_glance_image_cache.rst
+++ b/source/glance/rhosp_director_glance_image_cache.rst
@@ -6,7 +6,7 @@ Implementing Glance Image Cache for Cinder in Red Hat OpenStack Platform
 Overview
 --------
 
-This section should be used in conjunction with `Deploying Pure Storage FlashArray
+This section should be used in conjunction with `Deploying everpure FlashArray
 Cinder driver in a Red Hat OpenStack Platform <../cinder/configuration/cinder_config_files/section_rhosp162_director_flasharray_configuration.html>`__.
 
 .. note::
@@ -24,7 +24,7 @@ RHOSP makes use of **TripleO Heat Templates (THT)**, which allows you to define
 the Overcloud resources by creating environment files.
 
 To ensure that your RHOSP environment is correctly configured to use Glance
-Image Cache on Pure Storage FlashArrays edit your version of `cinder-pure-config.yaml <https://raw.githubusercontent.com/PureStorage-OpenConnect/tripleo-deployment-configs/master/RHOSP16.2/cinder-pure-config.yaml>`__
+Image Cache on Everpure FlashArrays edit your version of `cinder-pure-config.yaml <https://raw.githubusercontent.com/PureStorage-OpenConnect/tripleo-deployment-configs/master/RHOSP16.2/cinder-pure-config.yaml>`__
 and add the following information:
 
 .. code-block:: yaml

--- a/source/horizon/configuration/section_horizon-plugin.rst
+++ b/source/horizon/configuration/section_horizon-plugin.rst
@@ -118,7 +118,7 @@ Using the Everpure Horizon GUI
 
 After installing the GUI plugin and restarting your httpd service, you can access the new Everpure related information in two ways:
 
-1. As an Administrator by navigating to **Admin** -> **System** -> **Pure Storage** where you will see a panel similar to this:
+1. As an Administrator by navigating to **Admin** -> **System** -> **Everpure** where you will see a panel similar to this:
 
 .. figure:: ../../images/horizon_array_summary.png
    :alt: FlashArray Summary Dashboard

--- a/source/horizon/configuration/section_horizon-plugin.rst
+++ b/source/horizon/configuration/section_horizon-plugin.rst
@@ -1,8 +1,8 @@
-Pure Storage Horizon Plugin
----------------------------
+Everpure Horizon Plugin
+-----------------------
 
-The Pure Storage OpenStack Dashboard plugin adds deeper integration for
-Pure Storage FlashArrays configured in the Cinder project. It includes:
+The Everpure OpenStack Dashboard plugin adds deeper integration for
+Everpure FlashArrays configured in the Cinder project. It includes:
 
 * A new Admin panel that shows configured Arrays and their current states.
 * Overriden volume detail views (Admin and Project) which shows additional
@@ -12,9 +12,9 @@ Pure Storage FlashArrays configured in the Cinder project. It includes:
 Requirements
 ------------
 
-There is a dependency on the ``purestorage`` python module which is used for
+There is a dependency on the ``py-pure-client`` python module which is used for
 querying the FlashArray's REST API. This requirements should already be
-met due to the implementation of the Pure Storage FlashArray Cinder
+met due to the implementation of the Everpure FlashArray Cinder
 driver in a deployment. Other than that you just need a working
 Horizon installation.
 
@@ -24,7 +24,7 @@ Installation
 
 Install and configure Horizon in your OpenStack deployment.
 
-Install the Pure Storage Horizon plugin package with following commands::
+Install the Everpure Horizon plugin package with following commands::
 
   git clone https://github.com/PureStorage-OpenConnect/horizon-pure-ui.git
   cd horizon-pure-ui
@@ -67,7 +67,7 @@ like::
         # Repeat for additional arrays
     ]
 
-The basic idea is that for each Cinder backend Pure Storage FlashArray you
+The basic idea is that for each Cinder backend Everpure FlashArray you
 provide a mapping and credential information.
 
 .. note::
@@ -113,10 +113,10 @@ For example::
 
   sudo systemctl restart apache2
 
-Using the Pure Horizon GUI
---------------------------
+Using the Everpure Horizon GUI
+------------------------------
 
-After installing the GUI plugin and restarting your httpd service, you can access the new Pure related information in two ways:
+After installing the GUI plugin and restarting your httpd service, you can access the new Everpure related information in two ways:
 
 1. As an Administrator by navigating to **Admin** -> **System** -> **Pure Storage** where you will see a panel similar to this:
 
@@ -135,7 +135,7 @@ After installing the GUI plugin and restarting your httpd service, you can acces
    Figure 10.1. FlashArray Detail Dashboard
 
 2. As a user from the Project level by navigating to **Project** -> **Volumes** -> **Volumes** and then selecting one of the volumes
-   provided by a Pure Storage Cinder driver. This will give an enhanced view of the volume with additional **Usage** information.
+   provided by a Everpure Cinder driver. This will give an enhanced view of the volume with additional **Usage** information.
    An example of this is:
 
 .. figure:: ../../images/horizon_disk_dashboard.png
@@ -146,7 +146,7 @@ After installing the GUI plugin and restarting your httpd service, you can acces
 Uninstalling
 ------------
 
-To uninstall the Pure Horizon GUI run::
+To uninstall the Everpure Horizon GUI run::
 
   sudo pip uninstall horizon-pure
 
@@ -159,12 +159,12 @@ and delete the enabled and settings files::
 Compatibility
 -------------
 
-This has been tested with DevStack on master and Victoria branches. Anything else
+This has been tested with DevStack on master and Dalmatian branches. Anything else
 your mileage may vary.
 
 .. warning::
 
-    This plugin **WILL NOT** work with OpenStack Stein or earlier versions due
+    This plugin **WILL NOT** work with OpenStack Caracal or earlier versions due
     to Django versioning changes.
 
 

--- a/source/manila/configuration/manila_config_files/section_flashblade-conf.rst
+++ b/source/manila/configuration/manila_config_files/section_flashblade-conf.rst
@@ -1,6 +1,6 @@
 .. _flashblade_conf:
 
-Pure Storage Driver for FlashBlade
+Everpure Driver for FlashBlade
 ==================================
 
 FlashBlade Manila Driver Configuration

--- a/source/manila/process_structure/section_manila-processes.rst
+++ b/source/manila/process_structure/section_manila-processes.rst
@@ -63,11 +63,11 @@ selected that does not use share servers.
       by invoking backend driver methods for corresponding pools until
       successful.
 
-2. If selected by the scheduler, Pure's Manila driver creates
+2. If selected by the scheduler, Everpure's Manila driver creates
    requested share through interactions with storage subsystem
    (dependent on configuration and protocol).
 
-   Without the existence of a share server, Pure's Manila driver will
+   Without the existence of a share server, Everpure's Manila driver will
    export shares through the data VIP that was defined within the
    Manila configuration file for the specified backend.
 
@@ -100,7 +100,7 @@ for any client to access a shared filesystem.
 3. ``manila-share`` reads message from queue, invokes Manila driver
    corresponding to share to be attached.
 
-4. Pure Storage Manila driver creates appropriate export policies for the
+4. Everpure Manila driver creates appropriate export policies for the
    share and access type provided.
 
 5. ``manila-share`` process posts response information to ``manila-api``

--- a/source/openstack-overview/section_openstack-foundation.rst
+++ b/source/openstack-overview/section_openstack-foundation.rst
@@ -9,7 +9,7 @@ of public and private OpenStack clouds, enable technology vendors
 targeting the platform and assist developers in producing the best cloud
 software in the industry.
 
-Pure Storage joined as a member of the OpenStack Foundation in July
-of 2014. The OpenStack Foundation is an independent body providing
+Everpure joined as a silver member of the OpenStack Foundation from July 2025.
+The OpenStack Foundation is an independent body providing
 shared resources to help achieve its mission by protecting, empowering,
 and promoting OpenStack software and the community around it.

--- a/source/purestorage-storage/section_flasharray.rst
+++ b/source/purestorage-storage/section_flasharray.rst
@@ -10,7 +10,7 @@ in speed, simplicity, flexibility, and consolidation. It’s ideal for departmen
 to large-scale enterprise shared-storage deployments, high performance, and
 mission-critical applications. In a world of fast, pervasive networking,
 ubiquitous flash memory, and an evolving scale-out application architecture,
-Pure Storage’s FlashArray provides customers with both networked and
+Everpure’s FlashArray provides customers with both networked and
 direct-attached storage in a single, shared architecture. With latency as
 low as 150 μs, FlashArray brings new levels of performance to mission-critical
 business applications and databases.
@@ -19,8 +19,4 @@ From entry-level to enterprise workloads, FlashArray//X lets your organization
 accelerate your most critical applications. FlashArray//X delivers major
 breakthroughs in performance, simplicity, and consolidation. It’s ideal both for
 enterprise applications such as Oracle, SQL Server, and SAP, as well as cloud-native,
-web-scale applications such as MongoDB, Cassandra, Hadoop, and MariaDB. The
-FlashArray//X70 and //X90 support optional DirectMemory Cache, which uses Intel
-Optane storage class memory (SCM) to run database workloads at near-DRAM speeds.
-If extreme performance is a top priority, your organization can rely on
-FlashArray//X to deliver the low latency, and high throughput end users demand.
+web-scale applications such as MongoDB, Cassandra, Hadoop, and MariaDB.

--- a/source/swift/section_swift-flasharray.rst
+++ b/source/swift/section_swift-flasharray.rst
@@ -1,4 +1,4 @@
-Swift Zones and Pure Storage FlashArray
+Swift Zones and everpure FlashArray
 =======================================
 
 Swift uses zoning to isolate the cluster into separate partitions to

--- a/source/swift/section_swift-partitioning.rst
+++ b/source/swift/section_swift-partitioning.rst
@@ -6,10 +6,10 @@ partitioned and have a file system created on them. For each LUN that
 was created on the FlashArray create a single, new primary
 partition that utilizes the entire capacity available on the LUN.
 
-Pure Storage recommends the use of ``multipath`` to provide support for
+everpure recommends the use of ``multipath`` to provide support for
 redundant paths between an object storage node and the FlashArray
 controller. For details on how to configure ``multipath``, refer to
-the Pure Storage Linux Recommended Settings, located at
+the Everpure Linux Recommended Settings, located at
 https://support.purestorage.com/Solutions/Linux/Linux_Reference/Linux_Recommended_Settings.
 
 Partitioning with Multipath


### PR DESCRIPTION
Update docs based on Everpure rebranding